### PR TITLE
kernel: kpm: add compatibility for kernel 4.14 and lower

### DIFF
--- a/kernel/kpm/super_access.c
+++ b/kernel/kpm/super_access.c
@@ -167,7 +167,11 @@ DYNAMIC_STRUCT_BEGIN(task_struct)
     DEFINE_MEMBER(task_struct, group_leader)
     DEFINE_MEMBER(task_struct, mm)
     DEFINE_MEMBER(task_struct, active_mm)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0) 
+    DEFINE_MEMBER(task_struct, pids[PIDTYPE_PID].pid)
+#else
     DEFINE_MEMBER(task_struct, thread_pid)
+#endif
     DEFINE_MEMBER(task_struct, files)
     DEFINE_MEMBER(task_struct, seccomp)
 #ifdef CONFIG_THREAD_INFO_IN_TASK


### PR DESCRIPTION
`thread_pid` is not defined in kernel 4.14 and lower, leading to compilation issue. To fix this, use `pids[PIDTYPE_PID].pid` for kernel versions 4.14 and lower. Else use `thread_pid` for kernel versions 4.19 and higher.

Reference: https://github.com/yanivagman/BPFroid/blob/107717913bce95d6d5c232bf8dc4b11932b59d50/tracee/tracee.bpf.c#L354

❌ Merge
✅ Rebase and Merge.
❌ Squash and Merge