### PR TITLE
	修正Makefile中关于CONFIG_KSU_HOOK_KPROBES的错误

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -56,7 +56,7 @@ ifeq ($(strip $(CONFIG_KSU_MANUAL_HOOK)),y)
 $(info -- SukiSU: Manual hooking enabled!)
 else
 $(info -- SukiSU: KPROBES hooking enabled!)
-ccflags-y += -DCONFIG_KSU_KPROBES_HOOK
+cccflags-y += -DCONFIG_KSU_HOOK_KPROBES
 endif
 
 KERNEL_VERSION := $(VERSION).$(PATCHLEVEL)


### PR DESCRIPTION
改正ccflags-y += -DCONFIG_KSU_HOOK_KPROBES